### PR TITLE
Make sluggable behavior configurable

### DIFF
--- a/Model/Category.php
+++ b/Model/Category.php
@@ -32,7 +32,6 @@ class Category extends CategoriesAppModel {
  */
 	public $actsAs = array(
 		'Tree' => array('parent' => 'category_id'),
-		'Utils.Sluggable' => array('label' => 'name'),
 	);
 
 /**
@@ -84,6 +83,11 @@ class Category extends CategoriesAppModel {
 			'className' => $userClass,
 			'foreignKey' => 'user_id'
 		);
+
+		$this->actsAs['Utils.Sluggable'] = array_merge(array(
+			'label' => 'name'
+		), (array) Configure::read('Category.sluggable'));
+
 		parent::__construct($id, $table, $ds);
 		$this->validate = array(
 			'name' => array(


### PR DESCRIPTION
I much prefer using `-` instead of `_` characters in my seo urls, but the default in `Utils.SluggableBehavior` is `_`. This patch allows you to do so using the `Category.sluggable` configuration key.

I also made a few minor readability changes to keep the `Category` model inline with the cake core.
